### PR TITLE
Initial 1.16.5/Sponge API 8 Functionality (Currently Forge Only)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,40 +1,86 @@
+import org.spongepowered.gradle.plugin.config.PluginLoaders
+import org.spongepowered.plugin.metadata.model.PluginDependency
+
 buildscript {
   repositories {
+    mavenCentral()
     maven {
       name = "forge"
-      url = "http://files.minecraftforge.net/maven"
+      url = "https://files.minecraftforge.net/maven"
     }
   }
-
   dependencies {
-    classpath "net.minecraftforge.gradle:ForgeGradle:2.3-SNAPSHOT"
+    classpath group: 'net.minecraftforge.gradle', name: 'ForgeGradle', version: '5.1.+', changing: true
   }
 }
 
 plugins {
-  id "java"
+  id 'java'
+  id 'java-library'
   id "maven-publish"
-  id "net.minecrell.licenser" version "0.4.1"
-  id "com.github.johnrengelman.shadow" version "5.2.0"
-  id "net.minecrell.vanillagradle.server" version "2.2-6"
-  id "org.spongepowered.plugin" version "0.9.0"
+  id 'org.cadixdev.licenser' version '0.6.1'
+  id 'com.github.johnrengelman.shadow' version '7.1.2'
+  id "org.spongepowered.gradle.plugin" version "2.0.1"
+}
+
+apply plugin: 'net.minecraftforge.gradle'
+
+minecraft {
+  // The mappings can be changed at any time, and must be in the following format.
+  // snapshot_YYYYMMDD   Snapshot are built nightly.
+  // stable_#            Stables are built at the discretion of the MCP team.
+  // Use non-default mappings at your own risk. they may not always work.
+  // Simply re-run your setup task after changing the mappings to update your workspace.
+  mappings channel: 'official', version: '1.16.5'
 }
 
 group = "com.ichorpowered"
 version = "0.1.0-SNAPSHOT"
 description = "A minimal packet manipulation library for Sponge."
 
-sponge.plugin.id = project.name
-
 sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
 
+sponge {
+  apiVersion("8.0.0")
+  license("MIT")
+  loader {
+    name(PluginLoaders.JAVA_PLAIN)
+    version("1.0")
+  }
+  plugin("protocolcontrol") {
+    displayName("Protocol Control")
+    entrypoint("com.ichorpowered.protocolcontrol.ProtocolPlugin")
+    description("${project.description}")
+    links {
+      source("https://github.com/vectrix-space/protocolcontrol")
+      issues("https://github.com/vectrix-space/protocolcontrol/issues")
+    }
+    contributor("Vectrix") {
+      description("Project Owner/Developer")
+    }
+    dependency("spongeapi") {
+      loadOrder(PluginDependency.LoadOrder.AFTER)
+      optional(false)
+    }
+  }
+}
+
 repositories {
+  mavenCentral()
   maven {
     url "https://oss.sonatype.org/content/repositories/snapshots"
   }
+//  maven {
+//    url "https://repo.ichorpowered.com/repository/maven-public"
+//  }
   maven {
-    url "https://repo.ichorpowered.com/repository/maven-public"
+    name 'Sponge Releases'
+    url 'https://repo.spongepowered.org/repository/maven-releases'
+  }
+  maven {
+    name 'Sponge Snapshots'
+    url 'https://repo.spongepowered.org/repository/maven-snapshots'
   }
 }
 
@@ -51,25 +97,21 @@ license {
 }
 
 dependencies {
-  compile "com.ichorpowered:indigo:1.0.0-SNAPSHOT"
-  compile "net.kyori:mu:1.0.0-SNAPSHOT"
-  compile "net.kyori:violet:1.2.0-SNAPSHOT"
-  compile "net.kyori:event-method-asm:4.0.0-SNAPSHOT"
-  compileOnly "org.spongepowered:spongeapi:7.3.0"
-  compileOnly "org.spongepowered:spongecommon:1.12.2-7.3.0:dev"
-  annotationProcessor "org.spongepowered:spongeapi:7.3.0"
+  minecraft 'net.minecraftforge:forge:1.16.5-36.2.20'
+
+  implementation "net.kyori:indigo:1.0.0-SNAPSHOT"
+  implementation "net.kyori:mu:1.0.0-SNAPSHOT"
+  implementation "net.kyori:violet:1.2.0-SNAPSHOT"
+  implementation "net.kyori:event-method-asm:4.0.0-SNAPSHOT"
+  implementation 'com.google.inject:guice:4.1.0'
+  compileOnly group: 'org.spongepowered', name: 'math', version: '2.0.1'
+  //compileOnly "org.spongepowered:sponge:1.16.5-8.0.0-SNAPSHOT:dev"
 }
 
 tasks.withType(JavaCompile) {
   options.compilerArgs += ["-Xlint:all", "-Xlint:-path", "-parameters"]
   options.deprecation = true
   options.encoding = "UTF-8"
-}
-
-minecraft {
-  version = "1.12.2"
-  mappings = "snapshot_20180808"
-  makeObfSourceJar = false
 }
 
 jar {
@@ -110,26 +152,33 @@ task javadocsJar(type: Jar) {
 
 shadowJar {
   classifier = "shaded"
-  dependsOn reobfJar
 
   dependencies {
-    include(dependency("com.ichorpowered:indigo"))
+    include(dependency("net.kyori:indigo"))
 
     include(dependency("net.kyori:mu"))
     include(dependency("net.kyori:violet"))
     include(dependency("net.kyori:event-api"))
     include(dependency("net.kyori:event-method"))
     include(dependency("net.kyori:event-method-asm"))
-    include(dependency("net.kyori:examination-api"))
+    //include(dependency("net.kyori:examination-api"))
 
+    include(dependency("com.google.inject:guice"))
     include(dependency("com.google.inject.extensions:guice-assistedinject"))
     include(dependency("com.google.inject.extensions:guice-multibindings"))
   }
 
-  relocate("com.ichorpowered.indigo", "com.ichorpowered.indigo.lib.indigo")
-  relocate("net.kyori", "com.ichorpowered.protocolcontrol.lib.kyori")
-
+  relocate('com.google.guice', 'com.ichorpowered.protocolcontrol.lib.guice')
+  relocate("net.kyori.mu", "com.ichorpowered.protocolcontrol.lib.kyori.mu")
+  relocate("net.kyori.violet", "com.ichorpowered.protocolcontrol.lib.kyori.violet")
+  relocate("net.kyori.event-api", "com.ichorpowered.protocolcontrol.lib.kyori.event-api")
+  relocate("net.kyori.event-method", "com.ichorpowered.protocolcontrol.lib.kyori.event-method")
+  relocate("net.kyori.event-method-asm", "com.ichorpowered.protocolcontrol.lib.kyori.event-method-asm")
   exclude "dummyThing"
+}
+
+reobf {
+  shadowJar {}
 }
 
 def ichorpoweredUsername = System.getenv("ICHORPOWERED_USERNAME")
@@ -191,3 +240,6 @@ publishing {
     }
   }
 }
+
+checkLicenseMain.dependsOn(updateLicenses)
+build.dependsOn reobfShadowJar

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/ichorpowered/protocolcontrol/ProtocolChannel.java
+++ b/src/main/java/com/ichorpowered/protocolcontrol/ProtocolChannel.java
@@ -42,12 +42,12 @@ public final class ProtocolChannel {
   private final ConcurrentMap<UUID, ChannelProfile> channels = Maps.newConcurrentMap();
   private boolean enabled = false;
 
-  protected void enable() {
+  void enable() {
     if(this.enabled) return;
     this.enabled = true;
   }
 
-  protected void disable() {
+  void disable() {
     if(!this.enabled) return;
     this.enabled = false;
     this.channels.clear();

--- a/src/main/java/com/ichorpowered/protocolcontrol/ProtocolEvent.java
+++ b/src/main/java/com/ichorpowered/protocolcontrol/ProtocolEvent.java
@@ -45,8 +45,8 @@ import net.kyori.event.PostResult;
 import net.kyori.event.SimpleEventBus;
 import net.kyori.event.method.MethodSubscriptionAdapter;
 import net.kyori.event.method.asm.ASMEventExecutorFactory;
+import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.slf4j.Logger;
 
 import static java.util.Objects.requireNonNull;
 
@@ -66,7 +66,7 @@ public final class ProtocolEvent {
     this.logger = logger;
   }
 
-  protected void enable() {
+  void enable() {
     if(this.enabled) return;
     this.bus = new SimpleEventBus<Object>(Object.class) {
       @Override
@@ -92,7 +92,7 @@ public final class ProtocolEvent {
     this.enabled = true;
   }
 
-  protected void disable() {
+  void disable() {
     if(!this.enabled) return;
     this.bus.unregisterAll();
     this.service.shutdownNow();

--- a/src/main/java/com/ichorpowered/protocolcontrol/ProtocolInjector.java
+++ b/src/main/java/com/ichorpowered/protocolcontrol/ProtocolInjector.java
@@ -33,7 +33,7 @@ import java.lang.reflect.Field;
 import java.util.List;
 import net.minecraft.network.NetworkSystem;
 import net.minecraft.server.MinecraftServer;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
 import org.spongepowered.api.Game;
 
 @Singleton
@@ -58,14 +58,16 @@ public final class ProtocolInjector {
   }
 
   @SuppressWarnings({"unchecked", "JavaReflectionMemberAccess"})
-  protected void setup() {
+  void setup() {
     if(this.setup) return;
 
     Exceptions.catchingReport(
       () -> {
         final Field networkField = MinecraftServer.class.getDeclaredField("field_147144_o");
-        final NetworkSystem networkSystem = (NetworkSystem) networkField.get(this.game.getServer());
+        networkField.setAccessible(true);
+        final NetworkSystem networkSystem = (NetworkSystem) networkField.get(this.game.server());
         final Field endpointsField = networkSystem.getClass().getDeclaredField("field_151274_e");
+        endpointsField.setAccessible(true);
         this.endpoints = (List<ChannelFuture>) endpointsField.get(networkSystem);
         this.setup = true;
       },
@@ -76,7 +78,7 @@ public final class ProtocolInjector {
     );
   }
 
-  protected void enable() {
+  void enable() {
     if(this.enabled || !this.setup) return;
     Exceptions.catchingReport(
       () -> {
@@ -92,7 +94,7 @@ public final class ProtocolInjector {
     );
   }
 
-  protected void disable() {
+  void disable() {
     if(!this.enabled) return;
     Exceptions.catchingReport(
       () -> {

--- a/src/main/java/com/ichorpowered/protocolcontrol/channel/ChannelInitializer.java
+++ b/src/main/java/com/ichorpowered/protocolcontrol/channel/ChannelInitializer.java
@@ -34,7 +34,7 @@ import com.ichorpowered.protocolcontrol.util.Exceptions;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
 
 @Singleton
 public final class ChannelInitializer extends ChannelInboundHandlerAdapter {

--- a/src/main/java/com/ichorpowered/protocolcontrol/channel/ChannelProfile.java
+++ b/src/main/java/com/ichorpowered/protocolcontrol/channel/ChannelProfile.java
@@ -38,12 +38,12 @@ import java.util.function.Consumer;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.spongepowered.api.Sponge;
-import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.entity.living.player.server.ServerPlayer;
 
 public final class ChannelProfile {
   private final Channel channel;
   private @Nullable UUID id;
-  private WeakReference<Player> player;
+  private WeakReference<ServerPlayer> player;
   private boolean active = false;
 
   @Inject
@@ -74,7 +74,7 @@ public final class ChannelProfile {
    *
    * @return the player, if present
    */
-  public @NonNull Optional<Player> player() {
+  public @NonNull Optional<ServerPlayer> player() {
     if(this.id == null) return Optional.empty();
     if(this.player != null) return Optional.ofNullable(this.player.get());
     return this.player(this.id);
@@ -162,9 +162,9 @@ public final class ChannelProfile {
     }
   }
 
-  private @NonNull Optional<Player> player(final @NonNull UUID id) {
+  private @NonNull Optional<ServerPlayer> player(final @NonNull UUID id) {
     if(!Sponge.isServerAvailable()) return Optional.empty();
-    final Optional<Player> optionalPlayer = Sponge.getServer().getPlayer(id);
+    final Optional<ServerPlayer> optionalPlayer = Sponge.server().player(id);
     optionalPlayer.ifPresent(value -> this.player = new WeakReference<>(value));
     return optionalPlayer;
   }

--- a/src/main/java/com/ichorpowered/protocolcontrol/packet/PacketRemapper.java
+++ b/src/main/java/com/ichorpowered/protocolcontrol/packet/PacketRemapper.java
@@ -32,9 +32,10 @@ import com.ichorpowered.protocolcontrol.packet.translator.Translator;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.util.Map;
+
+import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.slf4j.Logger;
 
 import static java.util.Objects.requireNonNull;
 

--- a/src/main/java/com/ichorpowered/protocolcontrol/packet/PacketStructure.java
+++ b/src/main/java/com/ichorpowered/protocolcontrol/packet/PacketStructure.java
@@ -35,9 +35,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
+
+import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.slf4j.Logger;
 
 import static java.util.Objects.requireNonNull;
 
@@ -48,8 +49,8 @@ import static java.util.Objects.requireNonNull;
  */
 @SuppressWarnings("UnstableApiUsage")
 public final class PacketStructure {
-  protected static @NonNull PacketStructure generate(final @NonNull Logger logger, final MethodHandles.@NonNull Lookup lookup,
-                                                     final @NonNull Class<?> packet) {
+  static @NonNull PacketStructure generate(final @NonNull Logger logger, final MethodHandles.@NonNull Lookup lookup,
+                                           final @NonNull Class<?> packet) {
     final Map<TypeToken<?>, List<Handle>> handleMap = Maps.newHashMap();
     PacketStructure.find(packet, Class::getSuperclass, fields -> {
       for(final Field field : fields) {
@@ -74,8 +75,8 @@ public final class PacketStructure {
     return new PacketStructure(packet, handleMap);
   }
 
-  protected static void find(final @NonNull Class<?> search, final @NonNull Function<Class<?>, Class<?>> superSearch,
-                             final @NonNull Consumer<Field[]> fieldSearch) {
+  private static void find(final @NonNull Class<?> search, final @NonNull Function<Class<?>, Class<?>> superSearch,
+                           final @NonNull Consumer<Field[]> fieldSearch) {
     Class<?> searchClass = search;
     while(searchClass != null) {
       final Field[] fields = searchClass.getDeclaredFields();

--- a/src/main/java/com/ichorpowered/protocolcontrol/packet/PacketTranslations.java
+++ b/src/main/java/com/ichorpowered/protocolcontrol/packet/PacketTranslations.java
@@ -24,7 +24,6 @@
  */
 package com.ichorpowered.protocolcontrol.packet;
 
-import com.flowpowered.math.vector.Vector3i;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.reflect.TypeToken;
@@ -41,27 +40,28 @@ import com.ichorpowered.protocolcontrol.packet.translator.type.Vector3iTranslato
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
+
+import net.kyori.adventure.audience.MessageType;
+import net.kyori.adventure.bossbar.BossBar;
+import net.kyori.adventure.sound.Sound;
+import net.kyori.adventure.text.Component;
 import org.spongepowered.api.advancement.Advancement;
 import org.spongepowered.api.advancement.AdvancementProgress;
 import org.spongepowered.api.block.BlockState;
 import org.spongepowered.api.block.BlockType;
-import org.spongepowered.api.boss.BossBarColor;
-import org.spongepowered.api.boss.BossBarOverlay;
 import org.spongepowered.api.data.type.HandPreference;
 import org.spongepowered.api.data.type.HandType;
 import org.spongepowered.api.effect.particle.ParticleType;
 import org.spongepowered.api.effect.potion.PotionEffectType;
-import org.spongepowered.api.effect.sound.SoundCategory;
 import org.spongepowered.api.effect.sound.SoundType;
+import org.spongepowered.api.entity.living.player.chat.ChatVisibility;
 import org.spongepowered.api.entity.living.player.gamemode.GameMode;
 import org.spongepowered.api.item.inventory.ItemStack;
 import org.spongepowered.api.item.inventory.equipment.EquipmentType;
 import org.spongepowered.api.profile.GameProfile;
-import org.spongepowered.api.text.Text;
-import org.spongepowered.api.text.chat.ChatType;
-import org.spongepowered.api.text.chat.ChatVisibility;
-import org.spongepowered.api.world.GeneratorType;
+import org.spongepowered.api.world.World;
 import org.spongepowered.api.world.difficulty.Difficulty;
+import org.spongepowered.math.vector.Vector3i;
 
 @Singleton
 @SuppressWarnings("UnstableApiUsage")
@@ -75,28 +75,28 @@ public final class PacketTranslations {
 
   public void register() {
     this.translation.translate(TypeToken.of(AdvancementProgress.class), new DelegateTranslator<>(TypeToken.of(net.minecraft.advancements.AdvancementProgress.class)));
-    this.translation.translate(TypeToken.of(BlockState.class), new DelegateTranslator<>(TypeToken.of(net.minecraft.block.state.IBlockState.class)));
+    this.translation.translate(TypeToken.of(BlockState.class), new DelegateTranslator<>(TypeToken.of(net.minecraft.block.BlockState.class)));
     this.translation.translate(TypeToken.of(BlockType.class), new DelegateTranslator<>(TypeToken.of(net.minecraft.block.Block.class)));
-    this.translation.translate(TypeToken.of(BossBarColor.class), new DelegateTranslator<>(TypeToken.of(net.minecraft.world.BossInfo.Color.class)));
-    this.translation.translate(TypeToken.of(BossBarOverlay.class), new DelegateTranslator<>(TypeToken.of(net.minecraft.world.BossInfo.Overlay.class)));
-    this.translation.translate(TypeToken.of(ChatType.class), new DelegateTranslator<>(TypeToken.of(net.minecraft.util.text.ChatType.class)));
-    this.translation.translate(TypeToken.of(ChatVisibility.class), new DelegateTranslator<>(TypeToken.of(net.minecraft.entity.player.EntityPlayer.EnumChatVisibility.class)));
-    this.translation.translate(TypeToken.of(Difficulty.class), new DelegateTranslator<>(TypeToken.of(net.minecraft.world.EnumDifficulty.class)));
-    this.translation.translate(TypeToken.of(EquipmentType.class), new DelegateTranslator<>(TypeToken.of(net.minecraft.inventory.EntityEquipmentSlot.class)));
+    this.translation.translate(TypeToken.of(BossBar.Color.class), new DelegateTranslator<>(TypeToken.of(net.minecraft.world.BossInfo.Color.class)));
+    this.translation.translate(TypeToken.of(BossBar.Overlay.class), new DelegateTranslator<>(TypeToken.of(net.minecraft.world.BossInfo.Overlay.class)));
+    this.translation.translate(TypeToken.of(MessageType.class), new DelegateTranslator<>(TypeToken.of(net.minecraft.util.text.ChatType.class)));
+    this.translation.translate(TypeToken.of(ChatVisibility.class), new DelegateTranslator<>(TypeToken.of(net.minecraft.entity.player.ChatVisibility.class)));
+    this.translation.translate(TypeToken.of(Difficulty.class), new DelegateTranslator<>(TypeToken.of(net.minecraft.world.Difficulty.class)));
+    this.translation.translate(TypeToken.of(EquipmentType.class), new DelegateTranslator<>(TypeToken.of(net.minecraft.inventory.EquipmentSlotType.class)));
     this.translation.translate(TypeToken.of(GameMode.class), new DelegateTranslator<>(TypeToken.of(net.minecraft.world.GameType.class)));
     this.translation.translate(TypeToken.of(GameProfile.class), new DelegateTranslator<>(TypeToken.of(com.mojang.authlib.GameProfile.class)));
-    this.translation.translate(TypeToken.of(GeneratorType.class), new DelegateTranslator<>(TypeToken.of(net.minecraft.world.WorldType.class)));
-    this.translation.translate(TypeToken.of(HandPreference.class), new DelegateTranslator<>(TypeToken.of(net.minecraft.util.EnumHandSide.class)));
-    this.translation.translate(TypeToken.of(HandType.class), new DelegateTranslator<>(TypeToken.of(net.minecraft.util.EnumHand.class)));
+//    this.translation.translate(TypeToken.of(World.class), new DelegateTranslator<>(TypeToken.of(net.minecraft.world.WorldType.class)));
+    this.translation.translate(TypeToken.of(HandPreference.class), new DelegateTranslator<>(TypeToken.of(net.minecraft.util.HandSide.class)));
+    this.translation.translate(TypeToken.of(HandType.class), new DelegateTranslator<>(TypeToken.of(net.minecraft.util.Hand.class)));
     this.translation.translate(TypeToken.of(ItemStack.class), new DelegateTranslator<>(TypeToken.of(net.minecraft.item.ItemStack.class)));
-    this.translation.translate(TypeToken.of(ParticleType.class), new DelegateTranslator<>(TypeToken.of(net.minecraft.util.EnumParticleTypes.class)));
+    this.translation.translate(TypeToken.of(ParticleType.class), new DelegateTranslator<>(TypeToken.of(net.minecraft.particles.ParticleTypes.class)));
     this.translation.translate(TypeToken.of(PotionEffectType.class), new DelegateTranslator<>(TypeToken.of(net.minecraft.potion.Potion.class)));
-    this.translation.translate(TypeToken.of(SoundCategory.class), new DelegateTranslator<>(TypeToken.of(net.minecraft.util.SoundCategory.class)));
+    this.translation.translate(TypeToken.of(Sound.Source.class), new DelegateTranslator<>(TypeToken.of(net.minecraft.util.SoundCategory.class)));
     this.translation.translate(TypeToken.of(SoundType.class), new DelegateTranslator<>(TypeToken.of(net.minecraft.util.SoundEvent.class)));
 
     this.translation.translate(new TypeToken<Collection<Advancement>>() {}, new AdvancementAdditionsTranslator());
     this.translation.translate(TypeToken.of(ResourceKey.class), new ResourceKeyTranslator());
-    this.translation.translate(TypeToken.of(Text.class), new ComponentTextTranslator());
+    this.translation.translate(TypeToken.of(Component.class), new ComponentTextTranslator());
     this.translation.translate(TypeToken.of(Vector3i.class), new Vector3iTranslator());
 
     this.translation.translate(new TypeToken<Set<ResourceKey>>() {}, new ForwardingCollectionTranslator<>(

--- a/src/main/java/com/ichorpowered/protocolcontrol/packet/PacketType.java
+++ b/src/main/java/com/ichorpowered/protocolcontrol/packet/PacketType.java
@@ -25,115 +25,141 @@
 package com.ichorpowered.protocolcontrol.packet;
 
 import com.google.common.reflect.TypeToken;
-import net.minecraft.network.login.client.CPacketLoginStart;
-import net.minecraft.network.login.server.SPacketLoginSuccess;
-import net.minecraft.network.play.client.CPacketAnimation;
-import net.minecraft.network.play.client.CPacketChatMessage;
-import net.minecraft.network.play.client.CPacketClickWindow;
-import net.minecraft.network.play.client.CPacketClientSettings;
-import net.minecraft.network.play.client.CPacketClientStatus;
-import net.minecraft.network.play.client.CPacketCloseWindow;
-import net.minecraft.network.play.client.CPacketConfirmTeleport;
-import net.minecraft.network.play.client.CPacketConfirmTransaction;
-import net.minecraft.network.play.client.CPacketCreativeInventoryAction;
-import net.minecraft.network.play.client.CPacketCustomPayload;
-import net.minecraft.network.play.client.CPacketEnchantItem;
-import net.minecraft.network.play.client.CPacketEntityAction;
-import net.minecraft.network.play.client.CPacketHeldItemChange;
-import net.minecraft.network.play.client.CPacketInput;
-import net.minecraft.network.play.client.CPacketKeepAlive;
-import net.minecraft.network.play.client.CPacketPlaceRecipe;
-import net.minecraft.network.play.client.CPacketPlayer;
-import net.minecraft.network.play.client.CPacketPlayerAbilities;
-import net.minecraft.network.play.client.CPacketPlayerDigging;
-import net.minecraft.network.play.client.CPacketPlayerTryUseItem;
-import net.minecraft.network.play.client.CPacketPlayerTryUseItemOnBlock;
-import net.minecraft.network.play.client.CPacketRecipeInfo;
-import net.minecraft.network.play.client.CPacketResourcePackStatus;
-import net.minecraft.network.play.client.CPacketSeenAdvancements;
-import net.minecraft.network.play.client.CPacketSpectate;
-import net.minecraft.network.play.client.CPacketSteerBoat;
-import net.minecraft.network.play.client.CPacketTabComplete;
-import net.minecraft.network.play.client.CPacketUpdateSign;
-import net.minecraft.network.play.client.CPacketUseEntity;
-import net.minecraft.network.play.client.CPacketVehicleMove;
-import net.minecraft.network.play.server.SPacketAdvancementInfo;
-import net.minecraft.network.play.server.SPacketAnimation;
-import net.minecraft.network.play.server.SPacketBlockAction;
-import net.minecraft.network.play.server.SPacketBlockBreakAnim;
-import net.minecraft.network.play.server.SPacketBlockChange;
-import net.minecraft.network.play.server.SPacketCamera;
-import net.minecraft.network.play.server.SPacketChangeGameState;
-import net.minecraft.network.play.server.SPacketChat;
-import net.minecraft.network.play.server.SPacketChunkData;
-import net.minecraft.network.play.server.SPacketCloseWindow;
-import net.minecraft.network.play.server.SPacketCollectItem;
-import net.minecraft.network.play.server.SPacketCombatEvent;
-import net.minecraft.network.play.server.SPacketConfirmTransaction;
-import net.minecraft.network.play.server.SPacketCooldown;
-import net.minecraft.network.play.server.SPacketCustomPayload;
-import net.minecraft.network.play.server.SPacketCustomSound;
-import net.minecraft.network.play.server.SPacketDestroyEntities;
-import net.minecraft.network.play.server.SPacketDisconnect;
-import net.minecraft.network.play.server.SPacketDisplayObjective;
-import net.minecraft.network.play.server.SPacketEffect;
-import net.minecraft.network.play.server.SPacketEntity;
-import net.minecraft.network.play.server.SPacketEntityAttach;
-import net.minecraft.network.play.server.SPacketEntityEffect;
-import net.minecraft.network.play.server.SPacketEntityEquipment;
-import net.minecraft.network.play.server.SPacketEntityHeadLook;
-import net.minecraft.network.play.server.SPacketEntityMetadata;
-import net.minecraft.network.play.server.SPacketEntityProperties;
-import net.minecraft.network.play.server.SPacketEntityStatus;
-import net.minecraft.network.play.server.SPacketEntityTeleport;
-import net.minecraft.network.play.server.SPacketEntityVelocity;
-import net.minecraft.network.play.server.SPacketExplosion;
-import net.minecraft.network.play.server.SPacketHeldItemChange;
-import net.minecraft.network.play.server.SPacketJoinGame;
-import net.minecraft.network.play.server.SPacketKeepAlive;
-import net.minecraft.network.play.server.SPacketMaps;
-import net.minecraft.network.play.server.SPacketMoveVehicle;
-import net.minecraft.network.play.server.SPacketMultiBlockChange;
-import net.minecraft.network.play.server.SPacketOpenWindow;
-import net.minecraft.network.play.server.SPacketParticles;
-import net.minecraft.network.play.server.SPacketPlaceGhostRecipe;
-import net.minecraft.network.play.server.SPacketPlayerAbilities;
-import net.minecraft.network.play.server.SPacketPlayerListHeaderFooter;
-import net.minecraft.network.play.server.SPacketPlayerListItem;
-import net.minecraft.network.play.server.SPacketPlayerPosLook;
-import net.minecraft.network.play.server.SPacketRecipeBook;
-import net.minecraft.network.play.server.SPacketRemoveEntityEffect;
-import net.minecraft.network.play.server.SPacketResourcePackSend;
-import net.minecraft.network.play.server.SPacketRespawn;
-import net.minecraft.network.play.server.SPacketScoreboardObjective;
-import net.minecraft.network.play.server.SPacketSelectAdvancementsTab;
-import net.minecraft.network.play.server.SPacketServerDifficulty;
-import net.minecraft.network.play.server.SPacketSetExperience;
-import net.minecraft.network.play.server.SPacketSetPassengers;
-import net.minecraft.network.play.server.SPacketSetSlot;
-import net.minecraft.network.play.server.SPacketSignEditorOpen;
-import net.minecraft.network.play.server.SPacketSoundEffect;
-import net.minecraft.network.play.server.SPacketSpawnExperienceOrb;
-import net.minecraft.network.play.server.SPacketSpawnGlobalEntity;
-import net.minecraft.network.play.server.SPacketSpawnMob;
-import net.minecraft.network.play.server.SPacketSpawnObject;
-import net.minecraft.network.play.server.SPacketSpawnPainting;
-import net.minecraft.network.play.server.SPacketSpawnPlayer;
-import net.minecraft.network.play.server.SPacketSpawnPosition;
-import net.minecraft.network.play.server.SPacketStatistics;
-import net.minecraft.network.play.server.SPacketTabComplete;
-import net.minecraft.network.play.server.SPacketTeams;
-import net.minecraft.network.play.server.SPacketTimeUpdate;
-import net.minecraft.network.play.server.SPacketTitle;
-import net.minecraft.network.play.server.SPacketUnloadChunk;
-import net.minecraft.network.play.server.SPacketUpdateBossInfo;
-import net.minecraft.network.play.server.SPacketUpdateHealth;
-import net.minecraft.network.play.server.SPacketUpdateScore;
-import net.minecraft.network.play.server.SPacketUpdateTileEntity;
-import net.minecraft.network.play.server.SPacketUseBed;
-import net.minecraft.network.play.server.SPacketWindowItems;
-import net.minecraft.network.play.server.SPacketWindowProperty;
-import net.minecraft.network.play.server.SPacketWorldBorder;
+import net.minecraft.network.login.client.CCustomPayloadLoginPacket;
+import net.minecraft.network.login.server.SCustomPayloadLoginPacket;
+import net.minecraft.network.login.server.SDisconnectLoginPacket;
+import net.minecraft.network.play.client.CAnimateHandPacket;
+import net.minecraft.network.play.client.CChatMessagePacket;
+import net.minecraft.network.play.client.CClickWindowPacket;
+import net.minecraft.network.play.client.CClientSettingsPacket;
+import net.minecraft.network.play.client.CClientStatusPacket;
+import net.minecraft.network.play.client.CCloseWindowPacket;
+import net.minecraft.network.play.client.CConfirmTeleportPacket;
+import net.minecraft.network.play.client.CConfirmTransactionPacket;
+import net.minecraft.network.play.client.CCreativeInventoryActionPacket;
+import net.minecraft.network.play.client.CCustomPayloadPacket;
+import net.minecraft.network.play.client.CEditBookPacket;
+import net.minecraft.network.play.client.CEnchantItemPacket;
+import net.minecraft.network.play.client.CEntityActionPacket;
+import net.minecraft.network.play.client.CHeldItemChangePacket;
+import net.minecraft.network.play.client.CInputPacket;
+import net.minecraft.network.play.client.CJigsawBlockGeneratePacket;
+import net.minecraft.network.play.client.CKeepAlivePacket;
+import net.minecraft.network.play.client.CLockDifficultyPacket;
+import net.minecraft.network.play.client.CMarkRecipeSeenPacket;
+import net.minecraft.network.play.client.CMoveVehiclePacket;
+import net.minecraft.network.play.client.CPickItemPacket;
+import net.minecraft.network.play.client.CPlaceRecipePacket;
+import net.minecraft.network.play.client.CPlayerAbilitiesPacket;
+import net.minecraft.network.play.client.CPlayerDiggingPacket;
+import net.minecraft.network.play.client.CPlayerPacket;
+import net.minecraft.network.play.client.CPlayerTryUseItemOnBlockPacket;
+import net.minecraft.network.play.client.CPlayerTryUseItemPacket;
+import net.minecraft.network.play.client.CQueryEntityNBTPacket;
+import net.minecraft.network.play.client.CRenameItemPacket;
+import net.minecraft.network.play.client.CResourcePackStatusPacket;
+import net.minecraft.network.play.client.CSeenAdvancementsPacket;
+import net.minecraft.network.play.client.CSelectTradePacket;
+import net.minecraft.network.play.client.CSetDifficultyPacket;
+import net.minecraft.network.play.client.CSpectatePacket;
+import net.minecraft.network.play.client.CSteerBoatPacket;
+import net.minecraft.network.play.client.CTabCompletePacket;
+import net.minecraft.network.play.client.CUpdateBeaconPacket;
+import net.minecraft.network.play.client.CUpdateCommandBlockPacket;
+import net.minecraft.network.play.client.CUpdateJigsawBlockPacket;
+import net.minecraft.network.play.client.CUpdateMinecartCommandBlockPacket;
+import net.minecraft.network.play.client.CUpdateRecipeBookStatusPacket;
+import net.minecraft.network.play.client.CUpdateSignPacket;
+import net.minecraft.network.play.client.CUpdateStructureBlockPacket;
+import net.minecraft.network.play.client.CUseEntityPacket;
+import net.minecraft.network.play.server.SAdvancementInfoPacket;
+import net.minecraft.network.play.server.SAnimateBlockBreakPacket;
+import net.minecraft.network.play.server.SAnimateHandPacket;
+import net.minecraft.network.play.server.SBlockActionPacket;
+import net.minecraft.network.play.server.SCameraPacket;
+import net.minecraft.network.play.server.SChangeBlockPacket;
+import net.minecraft.network.play.server.SChangeGameStatePacket;
+import net.minecraft.network.play.server.SChatPacket;
+import net.minecraft.network.play.server.SChunkDataPacket;
+import net.minecraft.network.play.server.SCloseWindowPacket;
+import net.minecraft.network.play.server.SCollectItemPacket;
+import net.minecraft.network.play.server.SCombatPacket;
+import net.minecraft.network.play.server.SCommandListPacket;
+import net.minecraft.network.play.server.SConfirmTransactionPacket;
+import net.minecraft.network.play.server.SCooldownPacket;
+import net.minecraft.network.play.server.SCustomPayloadPlayPacket;
+import net.minecraft.network.play.server.SDestroyEntitiesPacket;
+import net.minecraft.network.play.server.SDisconnectPacket;
+import net.minecraft.network.play.server.SDisplayObjectivePacket;
+import net.minecraft.network.play.server.SEntityEquipmentPacket;
+import net.minecraft.network.play.server.SEntityHeadLookPacket;
+import net.minecraft.network.play.server.SEntityMetadataPacket;
+import net.minecraft.network.play.server.SEntityPacket;
+import net.minecraft.network.play.server.SEntityPropertiesPacket;
+import net.minecraft.network.play.server.SEntityStatusPacket;
+import net.minecraft.network.play.server.SEntityTeleportPacket;
+import net.minecraft.network.play.server.SEntityVelocityPacket;
+import net.minecraft.network.play.server.SExplosionPacket;
+import net.minecraft.network.play.server.SHeldItemChangePacket;
+import net.minecraft.network.play.server.SJoinGamePacket;
+import net.minecraft.network.play.server.SKeepAlivePacket;
+import net.minecraft.network.play.server.SMapDataPacket;
+import net.minecraft.network.play.server.SMerchantOffersPacket;
+import net.minecraft.network.play.server.SMountEntityPacket;
+import net.minecraft.network.play.server.SMoveVehiclePacket;
+import net.minecraft.network.play.server.SMultiBlockChangePacket;
+import net.minecraft.network.play.server.SOpenBookWindowPacket;
+import net.minecraft.network.play.server.SOpenHorseWindowPacket;
+import net.minecraft.network.play.server.SOpenSignMenuPacket;
+import net.minecraft.network.play.server.SOpenWindowPacket;
+import net.minecraft.network.play.server.SPlaceGhostRecipePacket;
+import net.minecraft.network.play.server.SPlayEntityEffectPacket;
+import net.minecraft.network.play.server.SPlaySoundEffectPacket;
+import net.minecraft.network.play.server.SPlaySoundEventPacket;
+import net.minecraft.network.play.server.SPlaySoundPacket;
+import net.minecraft.network.play.server.SPlayerAbilitiesPacket;
+import net.minecraft.network.play.server.SPlayerDiggingPacket;
+import net.minecraft.network.play.server.SPlayerListHeaderFooterPacket;
+import net.minecraft.network.play.server.SPlayerListItemPacket;
+import net.minecraft.network.play.server.SPlayerLookPacket;
+import net.minecraft.network.play.server.SPlayerPositionLookPacket;
+import net.minecraft.network.play.server.SQueryNBTResponsePacket;
+import net.minecraft.network.play.server.SRecipeBookPacket;
+import net.minecraft.network.play.server.SRemoveEntityEffectPacket;
+import net.minecraft.network.play.server.SRespawnPacket;
+import net.minecraft.network.play.server.SScoreboardObjectivePacket;
+import net.minecraft.network.play.server.SSelectAdvancementsTabPacket;
+import net.minecraft.network.play.server.SSendResourcePackPacket;
+import net.minecraft.network.play.server.SServerDifficultyPacket;
+import net.minecraft.network.play.server.SSetExperiencePacket;
+import net.minecraft.network.play.server.SSetPassengersPacket;
+import net.minecraft.network.play.server.SSetSlotPacket;
+import net.minecraft.network.play.server.SSpawnExperienceOrbPacket;
+import net.minecraft.network.play.server.SSpawnMobPacket;
+import net.minecraft.network.play.server.SSpawnMovingSoundEffectPacket;
+import net.minecraft.network.play.server.SSpawnObjectPacket;
+import net.minecraft.network.play.server.SSpawnPaintingPacket;
+import net.minecraft.network.play.server.SSpawnParticlePacket;
+import net.minecraft.network.play.server.SSpawnPlayerPacket;
+import net.minecraft.network.play.server.SStatisticsPacket;
+import net.minecraft.network.play.server.SStopSoundPacket;
+import net.minecraft.network.play.server.STabCompletePacket;
+import net.minecraft.network.play.server.STagsListPacket;
+import net.minecraft.network.play.server.STeamsPacket;
+import net.minecraft.network.play.server.STitlePacket;
+import net.minecraft.network.play.server.SUnloadChunkPacket;
+import net.minecraft.network.play.server.SUpdateChunkPositionPacket;
+import net.minecraft.network.play.server.SUpdateHealthPacket;
+import net.minecraft.network.play.server.SUpdateLightPacket;
+import net.minecraft.network.play.server.SUpdateRecipesPacket;
+import net.minecraft.network.play.server.SUpdateScorePacket;
+import net.minecraft.network.play.server.SUpdateTileEntityPacket;
+import net.minecraft.network.play.server.SUpdateTimePacket;
+import net.minecraft.network.play.server.SUpdateViewDistancePacket;
+import net.minecraft.network.play.server.SWindowItemsPacket;
+import net.minecraft.network.play.server.SWindowPropertyPacket;
+import net.minecraft.network.play.server.SWorldBorderPacket;
+import net.minecraft.network.play.server.SWorldSpawnChangedPacket;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -141,115 +167,131 @@ import static java.util.Objects.requireNonNull;
 
 /**
  * Represents the {@link PacketDirection#INCOMING} and {@link PacketDirection#OUTGOING}
- * packet types in the game as of version 1.12.2.
+ * packet types in the game as of version 1.16.5.
  */
 @SuppressWarnings({"unchecked", "UnstableApiUsage"})
 public enum PacketType {
-  ABILITIES(CPacketPlayerAbilities.class, SPacketPlayerAbilities.class),
-  ADVANCEMENT_INFO(null, SPacketAdvancementInfo.class),
-  ANIMATION(CPacketAnimation.class, SPacketAnimation.class),
-  BLOCK_ACTION(null, SPacketBlockAction.class),
-  BLOCK_BREAK_ANIMATION(null, SPacketBlockBreakAnim.class),
-  BLOCK_CHANGE(null, SPacketBlockChange.class),
-  CAMERA(null, SPacketCamera.class),
-  CHANGE_GAME_STATE(null, SPacketChangeGameState.class),
-  CHAT(CPacketChatMessage.class, SPacketChat.class),
-  CHUNK_DATA(null, SPacketChunkData.class),
-  CLICK_WINDOW(CPacketClickWindow.class, null),
-  CLIENT_SETTINGS(CPacketClientSettings.class, null),
-  CLIENT_STATUS(CPacketClientStatus.class, null),
-  CLOSE_WINDOW(CPacketCloseWindow.class, SPacketCloseWindow.class),
-  COLLECT_ITEM(null, SPacketCollectItem.class),
-  COMBAT_EVENT(null, SPacketCombatEvent.class),
-  CONFIRM_TELEPORT(CPacketConfirmTeleport.class, null),
-  CONFIRM_TRANSACTION(CPacketConfirmTransaction.class, SPacketConfirmTransaction.class),
-  COOLDOWN(null, SPacketCooldown.class),
-  CREATIVE_INVENTORY_ACTION(CPacketCreativeInventoryAction.class, null),
-  CUSTOM_PAYLOAD(CPacketCustomPayload.class, SPacketCustomPayload.class),
-  CUSTOM_SOUND(null, SPacketCustomSound.class),
-  DESTROY_ENTITIES(null, SPacketDestroyEntities.class),
-  DISCONNECT(null, SPacketDisconnect.class),
-  EFFECT(null, SPacketEffect.class),
-  ENCHANT_ITEM(CPacketEnchantItem.class, null),
-  ENTITY(null, SPacketEntity.class),
-  ENTITY_ACTION(CPacketEntityAction.class, null),
-  ENTITY_ATTACH(null, SPacketEntityAttach.class),
-  ENTITY_EFFECT(null, SPacketEntityEffect.class),
-  ENTITY_EQUIPMENT(null, SPacketEntityEquipment.class),
-  ENTITY_HEAD_LOOK(null, SPacketEntityHeadLook.class),
-  ENTITY_LOOK(null, SPacketEntity.S16PacketEntityLook.class),
-  ENTITY_METADATA(null, SPacketEntityMetadata.class),
-  ENTITY_MOVE_LOOK(null, SPacketEntity.S17PacketEntityLookMove.class),
-  ENTITY_PROPERTIES(null, SPacketEntityProperties.class),
-  ENTITY_STATUS(null, SPacketEntityStatus.class),
-  ENTITY_TELEPORT(null, SPacketEntityTeleport.class),
-  ENTITY_VELOCITY(null, SPacketEntityVelocity.class),
-  EXPLOSION(null, SPacketExplosion.class),
-  HELD_ITEM_CHANGE(CPacketHeldItemChange.class, SPacketHeldItemChange.class),
-  INPUT(CPacketInput.class, null),
-  JOIN_GAME(null, SPacketJoinGame.class),
-  KEEP_ALIVE(CPacketKeepAlive.class, SPacketKeepAlive.class),
-  LOGIN_START(CPacketLoginStart.class, null),
-  LOGIN_SUCCESS(null, SPacketLoginSuccess.class),
-  MAPS(null, SPacketMaps.class),
-  MULTI_BLOCK_CHANGE(null, SPacketMultiBlockChange.class),
-  OPEN_SIGN_EDITOR(null, SPacketSignEditorOpen.class),
-  OPEN_WINDOW(null, SPacketOpenWindow.class),
-  PARTICLES(null, SPacketParticles.class),
-  PLACE_RECIPE(CPacketPlaceRecipe.class, null),
-  PLACE_GHOST_RECIPE(null, SPacketPlaceGhostRecipe.class),
-  PLAYER_DIGGING(CPacketPlayerDigging.class, null),
-  PLAYER_LIST_HEADER_FOOTER(null, SPacketPlayerListHeaderFooter.class),
-  PLAYER_LIST_ITEM(null, SPacketPlayerListItem.class),
-  PLAYER_POSITION(CPacketPlayer.Position.class, null),
-  PLAYER_POSITION_LOOK(null, SPacketPlayerPosLook.class),
-  PLAYER_POSITION_ROTATION(CPacketPlayer.PositionRotation.class, null),
-  PLAYER_ROTATION(CPacketPlayer.Rotation.class, null),
-  RECIPE_BOOK(null, SPacketRecipeBook.class),
-  RECIPE_INFO(CPacketRecipeInfo.class, null),
-  REL_ENTITY_MOVE(null, SPacketEntity.S15PacketEntityRelMove.class),
-  REMOVE_ENTITY_EFFECT(null, SPacketRemoveEntityEffect.class),
-  RESOURCE_PACK_SEND(null, SPacketResourcePackSend.class),
-  RESOURCE_PACK_STATUS(CPacketResourcePackStatus.class, null),
-  RESPAWN(null, SPacketRespawn.class),
-  SCOREBOARD_DISPLAY_OBJECTIVE(null, SPacketDisplayObjective.class),
-  SCOREBOARD_OBJECTIVE(null, SPacketScoreboardObjective.class),
-  SCOREBOARD_SCORE(null, SPacketUpdateScore.class),
-  SEEN_ADVANCEMENTS(CPacketSeenAdvancements.class, null),
-  SELECT_ADVANCEMENTS(null, SPacketSelectAdvancementsTab.class),
-  SERVER_DIFFICULTY(null, SPacketServerDifficulty.class),
-  SET_EXPERIENCE(null, SPacketSetExperience.class),
-  SET_PASSENGERS(null, SPacketSetPassengers.class),
-  SET_SLOT(null, SPacketSetSlot.class),
-  SOUND(null, SPacketSoundEffect.class),
-  SPAWN_EXPERIENCE_ORB(null, SPacketSpawnExperienceOrb.class),
-  SPAWN_GLOBAL_ENTITY(null, SPacketSpawnGlobalEntity.class),
-  SPAWN_MOB(null, SPacketSpawnMob.class),
-  SPAWN_OBJECT(null, SPacketSpawnObject.class),
-  SPAWN_PAINTING(null, SPacketSpawnPainting.class),
-  SPAWN_PLAYER(null, SPacketSpawnPlayer.class),
-  SPAWN_POSITION(null, SPacketSpawnPosition.class),
-  SPECTATE(CPacketSpectate.class, null),
-  STATISTICS(null, SPacketStatistics.class),
-  STEER_BOAT(CPacketSteerBoat.class, null),
-  TAB_COMPLETE(CPacketTabComplete.class, SPacketTabComplete.class),
-  TEAMS(null, SPacketTeams.class),
-  TIME_UPDATE(null, SPacketTimeUpdate.class),
-  TITLE(null, SPacketTitle.class),
-  UNLOAD_CHUNK(null, SPacketUnloadChunk.class),
-  UNSPECIFIED(null, null),
-  UPDATE_BOSS(null, SPacketUpdateBossInfo.class),
-  UPDATE_HEALTH(null, SPacketUpdateHealth.class),
-  UPDATE_SIGN(CPacketUpdateSign.class, null),
-  UPDATE_TILE_ENTITY(null, SPacketUpdateTileEntity.class),
-  USE_BED(null, SPacketUseBed.class),
-  USE_ENTITY(CPacketUseEntity.class, null),
-  USE_ITEM(CPacketPlayerTryUseItem.class, null),
-  USE_ITEM_BLOCK(CPacketPlayerTryUseItemOnBlock.class, null),
-  VEHICLE_MOVE(CPacketVehicleMove.class, SPacketMoveVehicle.class),
-  WINDOW_ITEMS(null, SPacketWindowItems.class),
-  WINDOW_PROPERTY(null, SPacketWindowProperty.class),
-  WORLD_BORDER(null, SPacketWorldBorder.class);
+  ADVANCEMENT_INFO(null, SAdvancementInfoPacket.class),
+  ANIMATE_BLOCK_BREAK(null, SAnimateBlockBreakPacket.class),
+  ANIMATE_HAND(CAnimateHandPacket.class, SAnimateHandPacket.class),
+  BLOCK_ACTION(null, SBlockActionPacket.class),
+  CAMERA(null, SCameraPacket.class),
+  CHANGE_BLOCK(null, SChangeBlockPacket.class),
+  CHANGE_GAME_STATE(null, SChangeGameStatePacket.class),
+  CHAT(CChatMessagePacket.class, SChatPacket.class),
+  CHUNK_DATA(null, SChunkDataPacket.class),
+  CLICK_WINDOW(CClickWindowPacket.class, null),
+  CLIENT_SETTINGS(CClientSettingsPacket.class, null),
+  CLIENT_STATUS(CClientStatusPacket.class, null),
+  CLOSE_WINDOW(CCloseWindowPacket.class, SCloseWindowPacket.class),
+  COLLECT_ITEM(null, SCollectItemPacket.class),
+  COMBAT(null, SCombatPacket.class),
+  COMMAND_LIST(null, SCommandListPacket.class),
+  CONFIRM_TELEPORT(CConfirmTeleportPacket.class, null),
+  CONFIRM_TRANSACTION(CConfirmTransactionPacket.class, SConfirmTransactionPacket.class),
+  COOLDOWN(null, SCooldownPacket.class),
+  CREATIVE_INVENTORY_ACTION(CCreativeInventoryActionPacket.class, null),
+  CUSTOM_PAYLOAD_PLAY(CCustomPayloadPacket.class, SCustomPayloadPlayPacket.class),
+//  CUSTOM_PAYLOAD_LOGIN(CCustomPayloadLoginPacket.class, SCustomPayloadLoginPacket.class),
+  DESTROY_ENTITIES(null, SDestroyEntitiesPacket.class),
+  DISCONNECT(null, SDisconnectPacket.class),
+//  DISCONNECT_LOGIN(null, SDisconnectLoginPacket.class),
+  DISPLAY_OBJECTIVE(null, SDisplayObjectivePacket.class),
+  EDIT_BOOK(CEditBookPacket.class, null),
+  ENCHANT_ITEM(CEnchantItemPacket.class, null),
+  ENTITY_ACTION(CEntityActionPacket.class, null),
+  ENTITY_EQUIPMENT(null, SEntityEquipmentPacket.class),
+  ENTITY_HEAD_LOOK(null, SEntityHeadLookPacket.class),
+  ENTITY_METADATA(null, SEntityMetadataPacket.class),
+  ENTITY(null, SEntityPacket.class),
+  ENTITY_PROPERTIES(null, SEntityPropertiesPacket.class),
+  ENTITY_STATUS(null, SEntityStatusPacket.class),
+  ENTITY_TELEPORT(null, SEntityTeleportPacket.class),
+  ENTITY_VELOCITY(null, SEntityVelocityPacket.class),
+  EXPLOSION(null, SExplosionPacket.class),
+  HELD_ITEM_CHANGE(CHeldItemChangePacket.class, SHeldItemChangePacket.class),
+  INPUT(CInputPacket.class, null),
+  JIGSAW_BLOCK_GENERATE(CJigsawBlockGeneratePacket.class, null),
+  JOIN_GAME(null, SJoinGamePacket.class),
+  KEEP_ALIVE(CKeepAlivePacket.class, SKeepAlivePacket.class),
+  LOCK_DIFFICULTY(CLockDifficultyPacket.class, null),
+  MAP_DATA(null, SMapDataPacket.class),
+  MARK_RECIPE_SEEN(CMarkRecipeSeenPacket.class, null),
+  MERCHANT_OFFERS(null, SMerchantOffersPacket.class),
+  MOUNT_ENTITY(null, SMountEntityPacket.class),
+  MOVE_VEHICLE(CMoveVehiclePacket.class, SMoveVehiclePacket.class),
+  MULTI_BLOCK_CHANGE(null, SMultiBlockChangePacket.class),
+  OPEN_BOOK_WINDOW(null, SOpenBookWindowPacket.class),
+  OPEN_HORSE_WINDOW(null, SOpenHorseWindowPacket.class),
+  OPEN_SIGN_MENU(null, SOpenSignMenuPacket.class),
+  OPEN_WINDOW(null, SOpenWindowPacket.class),
+  PICK_ITEM(CPickItemPacket.class, null),
+  PLACE_RECIPE(CPlaceRecipePacket.class, SPlaceGhostRecipePacket.class),
+  PLAY_ENTITY_EFFECT(null, SPlayEntityEffectPacket.class),
+  PLAYER(CPlayerPacket.class, null),
+  PLAYER_ABILITIES(CPlayerAbilitiesPacket.class, SPlayerAbilitiesPacket.class),
+  PLAYER_DIGGING(CPlayerDiggingPacket.class, SPlayerDiggingPacket.class),
+  PLAYER_LIST_HEADER_FOOTER(null, SPlayerListHeaderFooterPacket.class),
+  PLAYER_LIST_ITEM(null, SPlayerListItemPacket.class),
+  PLAYER_LOOK(null, SPlayerLookPacket.class),
+  PLAYER_POSITION_LOOK(null, SPlayerPositionLookPacket.class),
+  PLAYER_TRY_USE_ITEM(CPlayerTryUseItemPacket.class, null),
+  PLAYER_TRY_USE_ITEM_ON_BLOCK(CPlayerTryUseItemOnBlockPacket.class, null),
+  PLAY_SOUND_EFFECT(null, SPlaySoundEffectPacket.class),
+  PLAY_SOUND_EVENT(null, SPlaySoundEventPacket.class),
+  PLAY_SOUND(null, SPlaySoundPacket.class),
+  QUERY_ENTITY_NBT(CQueryEntityNBTPacket.class, SQueryNBTResponsePacket.class),
+  QUERY_TILE_ENTITY_RESPONSE(CQueryEntityNBTPacket.class, SQueryNBTResponsePacket.class),
+  RECIPE_BOOK(null, SRecipeBookPacket.class),
+  REMOVE_ENTITY_EFFECT(null, SRemoveEntityEffectPacket.class),
+  RENAME_ITEM(CRenameItemPacket.class, null),
+  RESPAWN(null, SRespawnPacket.class),
+  SCOREBOARD_OBJECTIVE(null, SScoreboardObjectivePacket.class),
+  SELECT_ADVANCEMENTS_TAB(null, SSelectAdvancementsTabPacket.class),
+  SELECT_TRADE(CSelectTradePacket.class, null),
+  SEEN_ADVANCEMENTS(CSeenAdvancementsPacket.class, null),
+  SEND_RESOURCE_PACK(CResourcePackStatusPacket.class, SSendResourcePackPacket.class),
+  SERVER_DIFFICULTY(CSetDifficultyPacket.class, SServerDifficultyPacket.class),
+  SET_EXPERIENCE(null, SSetExperiencePacket.class),
+  SET_PASSENGERS(null, SSetPassengersPacket.class),
+  SET_SLOT(null, SSetSlotPacket.class),
+  SPAWN_EXPERIENCE_ORB(null, SSpawnExperienceOrbPacket.class),
+  SPAWN_MOB(null, SSpawnMobPacket.class),
+  SPAWN_MOVING_SOUND_EFFECT(null, SSpawnMovingSoundEffectPacket.class),
+  SPAWN_OBJECT(null, SSpawnObjectPacket.class),
+  SPAWN_PAINTING(null, SSpawnPaintingPacket.class),
+  SPAWN_PARTICLE(null, SSpawnParticlePacket.class),
+  SPAWN_PLAYER(null, SSpawnPlayerPacket.class),
+  SPECTATE(CSpectatePacket.class, null),
+  STATISTICS(null, SStatisticsPacket.class),
+  STEER_BOAT(CSteerBoatPacket.class, null),
+  STOP_SOUND(null, SStopSoundPacket.class),
+  TAB_COMPLETE(CTabCompletePacket.class, STabCompletePacket.class),
+  TAGS_LIST(null, STagsListPacket.class),
+  TEAMS(null, STeamsPacket.class),
+  TITLE(null, STitlePacket.class),
+  UNLOAD_CHUNK(null, SUnloadChunkPacket.class),
+  UPDATE_BEACON(CUpdateBeaconPacket.class, null),
+  UPDATE_CHUNK_POSITION(null, SUpdateChunkPositionPacket.class),
+  UPDATE_COMMAND_BLOCK(CUpdateCommandBlockPacket.class, null),
+  UPDATE_HEALTH(null, SUpdateHealthPacket.class),
+  UPDATE_JIGSAW_BLOCK(CUpdateJigsawBlockPacket.class, null),
+  UPDATE_LIGHT(null, SUpdateLightPacket.class),
+  UPDATE_MINECART_COMMAND_BLOCK(CUpdateMinecartCommandBlockPacket.class, null),
+  UPDATE_RECIPES(CUpdateRecipeBookStatusPacket.class, SUpdateRecipesPacket.class),
+  UPDATE_SIGN(CUpdateSignPacket.class, null),
+  UPDATE_SCORE(null, SUpdateScorePacket.class),
+  UPDATE_STRUCTURE_BLOCK(CUpdateStructureBlockPacket.class, null),
+  UPDATE_TILE_ENTITY(null, SUpdateTileEntityPacket.class),
+  UPDATE_TIME(null, SUpdateTimePacket.class),
+  UPDATE_VIEW_DISTANCE(null, SUpdateViewDistancePacket.class),
+  USE_ENTITY(CUseEntityPacket.class, null),
+  WINDOW_ITEMS(null, SWindowItemsPacket.class),
+  WINDOW_PROPERTY(null, SWindowPropertyPacket.class),
+  WORLD_BORDER(null, SWorldBorderPacket.class),
+  WORLD_SPAWN_CHANGED(null, SWorldSpawnChangedPacket.class),
+
+  UNSPECIFIED(null, null);
 
   private final Class<?> inboundType;
   private final Class<?> outboundType;

--- a/src/main/java/com/ichorpowered/protocolcontrol/packet/translator/type/AdvancementAdditionsTranslator.java
+++ b/src/main/java/com/ichorpowered/protocolcontrol/packet/translator/type/AdvancementAdditionsTranslator.java
@@ -55,7 +55,7 @@ public final class AdvancementAdditionsTranslator implements Translator<Collecti
     final Map<ResourceLocation, net.minecraft.advancements.Advancement.Builder> advancementMap = Maps.newHashMap();
     for(final Advancement advancement : translation) {
       final net.minecraft.advancements.Advancement element = (net.minecraft.advancements.Advancement) advancement;
-      advancementMap.put(element.getId(), element.copy());
+      advancementMap.put(element.getId(), element.deconstruct());
     }
     return (E) advancementMap;
   }

--- a/src/main/java/com/ichorpowered/protocolcontrol/packet/translator/type/ComponentTextTranslator.java
+++ b/src/main/java/com/ichorpowered/protocolcontrol/packet/translator/type/ComponentTextTranslator.java
@@ -26,25 +26,25 @@ package com.ichorpowered.protocolcontrol.packet.translator.type;
 
 import com.google.common.reflect.TypeToken;
 import com.ichorpowered.protocolcontrol.packet.translator.Translator;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import net.minecraft.util.text.ITextComponent;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.spongepowered.api.text.Text;
-import org.spongepowered.common.text.SpongeTexts;
 
 @SuppressWarnings({"unchecked", "UnstableApiUsage"})
-public final class ComponentTextTranslator implements Translator<Text> {
+public final class ComponentTextTranslator implements Translator<Component> {
   @Override
-  public @Nullable Text wrap(final @Nullable Object object) {
+  public @Nullable Component wrap(final @Nullable Object object) {
     if(object == null) return null;
     final ITextComponent message = (ITextComponent) object;
-    return SpongeTexts.toText(message);
+    return GsonComponentSerializer.gson().deserialize(ITextComponent.Serializer.toJson(message));
   }
 
   @Override
-  public <E> @Nullable E unwrap(final @Nullable Text translation) {
+  public <E> @Nullable E unwrap(final @Nullable Component translation) {
     if(translation == null) return null;
-    final ITextComponent message = SpongeTexts.toComponent(translation);
+    final ITextComponent message = ITextComponent.Serializer.fromJson(GsonComponentSerializer.gson().serializeToTree(translation));
     return (E) message;
   }
 

--- a/src/main/java/com/ichorpowered/protocolcontrol/service/ServiceProvider.java
+++ b/src/main/java/com/ichorpowered/protocolcontrol/service/ServiceProvider.java
@@ -22,33 +22,28 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package com.ichorpowered.protocolcontrol.packet.translator.type;
+package com.ichorpowered.protocolcontrol.service;
 
-import com.google.common.reflect.TypeToken;
-import com.ichorpowered.protocolcontrol.packet.translator.Translator;
-import net.minecraft.util.math.BlockPos;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
-import org.spongepowered.math.vector.Vector3i;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
-@SuppressWarnings({"unchecked", "UnstableApiUsage"})
-public final class Vector3iTranslator implements Translator<Vector3i> {
-  @Override
-  public @Nullable Vector3i wrap(final @Nullable Object object) {
-    if(object == null) return null;
-    final BlockPos blockPos = (BlockPos) object;
-    return new Vector3i(blockPos.getX(), blockPos.getY(), blockPos.getZ());
+public class ServiceProvider {
+
+  private static @MonotonicNonNull ProtocolService instance;
+
+  public static ProtocolService get() {
+    if(instance == null) {
+      throw new IllegalStateException("The Protocol Service has not yet been initialized!");
+    }
+
+    return instance;
   }
 
-  @Override
-  public <E> @Nullable E unwrap(final @Nullable Vector3i translation) {
-    if(translation == null) return null;
-    final BlockPos blockPos = new BlockPos(translation.x(), translation.y(), translation.z());
-    return (E) blockPos;
+  public static void register(ProtocolService instance) {
+    if(ServiceProvider.instance != null) {
+      throw new IllegalStateException("The protocol service can only be registered once!");
+    }
+
+    ServiceProvider.instance = instance;
   }
 
-  @Override
-  public @NonNull TypeToken<?> translatable() {
-    return TypeToken.of(BlockPos.class);
-  }
 }

--- a/src/main/java/com/ichorpowered/protocolcontrol/util/Exceptions.java
+++ b/src/main/java/com/ichorpowered/protocolcontrol/util/Exceptions.java
@@ -24,11 +24,12 @@
  */
 package com.ichorpowered.protocolcontrol.util;
 
-import com.ichorpowered.indigo.DetailedReport;
 import java.util.function.Consumer;
+
+import net.kyori.indigo.DetailedReport;
 import net.kyori.mu.function.ThrowingRunnable;
+import org.apache.logging.log4j.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
-import org.slf4j.Logger;
 
 public final class Exceptions {
   /**
@@ -144,6 +145,6 @@ public final class Exceptions {
    * @param report The report
    */
   public static void printReport(final @NonNull Logger logger, final @NonNull DetailedReport report) {
-    logger.error(String.format("%s:\n %s", report.message(), report.toString()));
+    logger.error(String.format("%s:\n %s", report.message(), report));
   }
 }


### PR DESCRIPTION
This provides initial 1.16.5/Sponge API 8 compatibility. There are likely some packet mappings to adjust, as well as additional improvements that can be made to the API (such as custom packet type definitions). 

At present, this code is only capable of running on Forge. Between SV and SF, there is some mapping incompatibility that will require some additional research to get working with both platforms. Due to environment issues, this was not tremendously tested, and was only verified for bootup success. Ideally, this should move away from ForgeGradle and instead use VanillaGradle, but perhaps there's an additional method we can use to have ForgeGradle mappings work with SV.

Notable differences:
* Upgraded Gradle to 7.3.3, FG to 5.1+ and SG 2.0.1
* Reverted indigo to base kyori distribution due to repository resolution issues
* To my knowledge, Sponge removed custom services on the service provider, so added a new ServiceProvider class responsible for providing the service.
* Updated access privileges where it made sense (IJ loved to complain about this)
* Removed reliance on SpongeCommon